### PR TITLE
Try build kmod for currente kernel and let it debug 

### DIFF
--- a/hid-ite8291r3-kmod.spec
+++ b/hid-ite8291r3-kmod.spec
@@ -72,6 +72,13 @@ done
 
 
 %build
+#for kernel_version  in %{?kernel_versions} ; do
+#    pushd  _kmod_build_${kernel_version%%___*}
+#    make %{?_smp_mflags} \
+#        KSRC=${kernel_version##*___} \
+#        KVERS=${kernel_version%%___*} modules
+#    popd
+#done
 for kernel_version in %{?kernel_versions}; do
     pushd  _kmod_build_${kernel_version%%___*}
     make %{?_smp_mflags} KDIR=${kernel_version##*___}

--- a/hid-ite8291r3-kmod.spec
+++ b/hid-ite8291r3-kmod.spec
@@ -2,7 +2,7 @@
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 
-%define buildforkernels akmod
+#define buildforkernels akmod
 %global debug_package %{nil}
 
 
@@ -25,13 +25,14 @@ Patch0: Makefile.patch
 # and fix the code (if needed).
 ExclusiveArch:  x86_64
 
+BuildRequires: buildsys-build-rpmfusion-kerneldevpkgs-current buildsys-build-rpmfusion
 
 %global AkmodsBuildRequires %{_bindir}/kmodtool xz time elfutils-libelf-devel gcc bc
 BuildRequires:  %{AkmodsBuildRequires}
 
 
 # kmodtool does its magic here
-%{expand:%(kmodtool --target %{_target_cpu} --repo fedora --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
+%{expand:%(kmodtool --target %{_target_cpu} --repo rpmfusion --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
 
 
 %description
@@ -54,7 +55,7 @@ Provides:       %{name}-common = %{version}-%{release}
 
 
 # print kmodtool output for debugging purposes:
-kmodtool  --target %{_target_cpu} --repo fedora --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null
+kmodtool  --target %{_target_cpu} --repo rpmfusion --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null
 
 
 %setup -q -c


### PR DESCRIPTION
`rfpkg --release f35  mockbuild --no-local-resultsdir -N --root fedora-35-x86_64-rpmfusion_free`
(...)
Build failed 
to debug: 
```
mock -r fedora-35-x86_64-rpmfusion_free --shell
su - mockbuild
cd build/BUILD/hid-ite8291r3-kmod-0.0/_kmod_build_5.18.7-100.fc35.x86_64/
make -j8 KDIR=/usr/src/kernels/5.18.7-100.fc35.x86_64
```
